### PR TITLE
Fix fallback for missing database entries

### DIFF
--- a/backend/controllers/countryController.js
+++ b/backend/controllers/countryController.js
@@ -55,7 +55,8 @@ const getAllCountries = async (req, res) => {
         let countries = await db.select('*').from('countries');
 
         if (!countries.length) {
-            const dataPath = path.join(__dirname, 'data.json');
+            // Fallback to the local JSON file when the database is empty
+            const dataPath = path.join(__dirname, '../data.json');
             const jsonData = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
             countries = jsonData;
         }
@@ -80,14 +81,30 @@ const getCountryDetails = async (req, res) => {
         // Find additional details from data.json
         const extraInfo = jsonData.find((c) => c.name.toLowerCase() === name.toLowerCase());
 
+        // If the country is not in the database, build the base object from data.json
+        if (!country && extraInfo) {
+            const flagUrl = typeof extraInfo.flags === 'string'
+                ? extraInfo.flags
+                : extraInfo.flags?.png || 'https://via.placeholder.com/150';
+
+            country = {
+                name: extraInfo.name || 'Unknown',
+                population: extraInfo.population || 0,
+                region: extraInfo.region || 'N/A',
+                capital: extraInfo.capital || 'N/A',
+                flag_url: flagUrl,
+                borders: Array.isArray(extraInfo.borders) ? extraInfo.borders : [],
+            };
+        }
+
         if (extraInfo) {
             country = {
-                ...country,
-                nativeName: extraInfo.nativeName || "Not Available",
-                subregion: extraInfo.subregion || "Not Available",
-                topLevelDomain: extraInfo.topLevelDomain || ["Not Available"],
-                currencies: extraInfo.currencies || [{ name: "Not Available" }],
-                languages: extraInfo.languages || [{ name: "Not Available" }],
+                ...(country || {}),
+                nativeName: extraInfo.nativeName || 'Not Available',
+                subregion: extraInfo.subregion || 'Not Available',
+                topLevelDomain: extraInfo.topLevelDomain || ['Not Available'],
+                currencies: extraInfo.currencies || [{ name: 'Not Available' }],
+                languages: extraInfo.languages || [{ name: 'Not Available' }],
             };
         }
 


### PR DESCRIPTION
## Summary
- use the correct path for data.json when the database is empty
- build country objects from data.json when missing in DB
- append extra details without crashing when DB entry is absent
- ensure file ends with a newline

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846e0634f40832f912c14414e1fc5d1