### PR TITLE
Add vitest and CountryCard test

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "axios": "^1.7.9",
@@ -25,6 +26,8 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.16",
     "globals": "^15.14.0",
-    "vite": "^6.0.5"
+    "vite": "^6.0.5",
+    "vitest": "^1.4.0",
+    "@testing-library/react": "^14.2.1"
   }
 }

--- a/client/src/components/__tests__/CountryCard.test.jsx
+++ b/client/src/components/__tests__/CountryCard.test.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import CountryCard from '../CountryCard.jsx';
+import { describe, it, expect } from 'vitest';
+
+const sampleCountry = {
+  name: 'France',
+  population: 67000000,
+  region: 'Europe',
+  capital: 'Paris',
+  flag_url: 'https://flagcdn.com/fr.svg'
+};
+
+describe('CountryCard', () => {
+  it('renders country information and flag', () => {
+    render(
+      <MemoryRouter>
+        <CountryCard country={sampleCountry} theme="light" />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('France')).toBeInTheDocument();
+    expect(screen.getByText(/population/i)).toHaveTextContent(
+      sampleCountry.population.toLocaleString()
+    );
+    expect(screen.getByText(/region/i)).toHaveTextContent('Europe');
+    expect(screen.getByText(/capital/i)).toHaveTextContent('Paris');
+
+    const flagImg = screen.getByAltText('France flag');
+    expect(flagImg).toBeInTheDocument();
+    expect(flagImg).toHaveAttribute('src', sampleCountry.flag_url);
+  });
+});


### PR DESCRIPTION
## Summary
- add `test` script running vitest
- install `vitest` and `@testing-library/react`
- create CountryCard component test

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e2cdb050832fa5126b1bc746e19f